### PR TITLE
Make safe to fake build on non-darwin

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,6 +1,10 @@
 # Setup
 import os
 import sys
+
+if sys.platform != 'darwin':
+    exit(0)
+
 env = Environment(ENV = os.environ)
 try:
     env.Tool('config', toolpath = [os.environ.get('CBANG_HOME')])


### PR DESCRIPTION
I would like to make this a dependancy of fah-client-bastet (in fah-build), so it can be bundled with the osx bastet installer in the future.